### PR TITLE
Mengubah interface untuk implementasi Affine Cipher.

### DIFF
--- a/encryption/affine.py
+++ b/encryption/affine.py
@@ -1,5 +1,6 @@
 from utils import get_int_representation_of, get_text_from
 
+import math
 import unittest
 
 
@@ -33,6 +34,9 @@ class Affine:
 
     @staticmethod
     def encrypt(plaintext, a = 5, b = 3):
+        if math.gcd(a, 26) > 1:
+            raise Exception('key a harus berupa bilangan yang coprime dengan 26')
+
         ENCRYPT_FUNC = lambda x: (a * x + b) % 26
 
         int_repr = get_int_representation_of(plaintext)
@@ -45,6 +49,9 @@ class Affine:
 
     @staticmethod
     def decrypt(ciphertext, a = 5, b = 3):
+        if math.gcd(a, 26) > 1:
+            raise Exception('key a harus berupa bilangan yang coprime dengan 26')
+
         a_invers = [i for i in range(26) if (a * i) % 26 == 1][0]
         DECRYPT_FUNC = lambda y: (a_invers * (y - b)) % 26
 
@@ -69,9 +76,14 @@ class AffineTest(unittest.TestCase):
             ciphertext = Affine.encrypt(c[0])
             self.assertEqual(expected, ciphertext)
 
-        # invalid test case
-        invalid_plaintext = '123!@#'
-        self.assertRaises(Exception, Affine.encrypt, invalid_plaintext)
+        invalid_cases = [
+            # (text, a, b)
+            ('123', 3, 5),  # invalid input
+            ('abc', 13, 2), # key a bukan coprime dari 26
+        ]
+
+        for c in invalid_cases:
+            self.assertRaises(Exception, Affine.encrypt, c[0], c[1], c[2])
 
 
     def test_decrypt(self):
@@ -85,9 +97,14 @@ class AffineTest(unittest.TestCase):
             plaintext = Affine.decrypt(c[0])
             self.assertEqual(expected, plaintext)
 
-        # invalid test case
-        invalid_ciphertext = '@12345'
-        self.assertRaises(Exception, Affine.decrypt, invalid_ciphertext)
+        invalid_cases = [
+            # (text, a, b)
+            ('123', 3, 5),  # invalid input
+            ('abc', 13, 2), # key a bukan coprime dari 26
+        ]
+
+        for c in invalid_cases:
+            self.assertRaises(Exception, Affine.decrypt, c[0], c[1], c[2])
 
 
     def test_encrypt_decrypt(self):

--- a/encryption/affine.py
+++ b/encryption/affine.py
@@ -25,7 +25,9 @@ class Affine:
 
             plaintext = 'hello world'
 
-            ciphertext = Affine.encrypt(plaintext)
+            a = 5
+            b = 3
+            ciphertext = Affine.encrypt(plaintext, a, b)
 
 
      2. Dekripsi
@@ -38,7 +40,9 @@ class Affine:
     '''
 
     @staticmethod
-    def encrypt(plaintext):
+    def encrypt(plaintext, a = 5, b = 3):
+        ENCRYPT_FUNC = lambda x: (a * x + b) % 26
+
         int_repr = get_int_representation_of(plaintext)
         if int_repr == None:
             raise Exception('tidak support karakter selain alfabet')

--- a/encryption/affine.py
+++ b/encryption/affine.py
@@ -91,12 +91,20 @@ class AffineTest(unittest.TestCase):
 
 
     def test_encrypt_decrypt(self):
-        texts = ['helloworld', 'affine', 'laksjfdpi', 'AAA']
+        cases = [
+            # (text, key_a, key_b)
+            ('helloworld', 3, 2),
+            ('affine', 5, 1),
+            ('laksjfdpi', 9, 5),
+            ('AAA', 11, 17),
+        ]
 
-        for text in texts:
-            encrypted = Affine.encrypt(text)
-            decrypted = Affine.decrypt(encrypted)
-            self.assertEqual(text.upper(), decrypted)
+        for c in cases:
+            a = c[1]
+            b = c[2]
+            encrypted = Affine.encrypt(c[0], a, b)
+            decrypted = Affine.decrypt(encrypted, a, b)
+            self.assertEqual(c[0].upper(), decrypted)
 
 
 if __name__ == '__main__':

--- a/encryption/affine.py
+++ b/encryption/affine.py
@@ -1,4 +1,4 @@
-from utils import get_int_representation_of, get_text_from
+from .utils import get_int_representation_of, get_text_from
 
 import math
 import unittest

--- a/encryption/affine.py
+++ b/encryption/affine.py
@@ -3,16 +3,6 @@ from utils import get_int_representation_of, get_text_from
 import unittest
 
 
-ENCRYPTION_KEY = (5, 3)
-
-ENCRYPT_FUNC = lambda x: (ENCRYPTION_KEY[0] * x + ENCRYPTION_KEY[1]) % 26
-# TODO: Buat logika untuk mendapatkan invers dari A.
-#       Pada fungsi dekripsi di bawah ini, invers dari
-#       A diberikan secara manual (hardcoded). Sehingga
-#       apabila encryption key berubah, maka fungsi ini
-#       harus diubah kembali
-DECRYPT_FUNC = lambda y: (21 * (y - ENCRYPTION_KEY[1])) % 26
-
 class Affine:
     '''
     Implementasi algoritma Affine Cipher.
@@ -36,7 +26,9 @@ class Affine:
 
             ciphertext = 'blah blah blah'
 
-            plaintext = Affine.decrypt(ciphertext)
+            a = 5
+            b = 3
+            plaintext = Affine.decrypt(ciphertext, a, b)
     '''
 
     @staticmethod
@@ -52,7 +44,10 @@ class Affine:
 
 
     @staticmethod
-    def decrypt(ciphertext):
+    def decrypt(ciphertext, a = 5, b = 3):
+        a_invers = [i for i in range(26) if (a * i) % 26 == 1][0]
+        DECRYPT_FUNC = lambda y: (a_invers * (y - b)) % 26
+
         int_repr = get_int_representation_of(ciphertext)
         if int_repr == None:
             raise Exception('invalid cipher text')


### PR DESCRIPTION
Menghilangkan key `a` dan `b` yang hardcoded di source code.

Versi sebelum:
```python
ciphertext = Affine.encrypt('foo')    # key tidak dapat diubah (a bernilai 5 dan b bernilai 3)
```

Versi baru:
```python
a = 7
b = 11

ciphertext = Affine.encrypt('foo', a, b)   # key sekarang dapat diberikan oleh user

plaintext = Affine.decrypt(ciphertext, a, b)
```

NOTE:
method `Affine.encrypt` dan `Affine.decrypt` hanya menerima key `a` yang merupakan
bilangan coprime dengan 26. Jika yang diberikan bukan coprime dengan 26, maka
method ini akan melemparkan `Exception`.